### PR TITLE
Fix #32 Disabilitato momentaneamente astro partytown per bug noto con firefox

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import UnoCSS from 'unocss/astro';
 import mdx from "@astrojs/mdx";
-import partytown from "@astrojs/partytown";
+//import partytown from "@astrojs/partytown";
 import { remarkModifiedTime } from './remark-modified-time.mjs';
 import { remarkReadingTime } from './remark-reading-time.mjs';
 
@@ -16,12 +16,12 @@ export default defineConfig({
   integrations: [sitemap(), UnoCSS({
     injectReset: true
   }), mdx(), react(),
-  partytown({
+  /*partytown({
     // Adds dataLayer.push as a forwarding-event.
     config: {
       forward: ["dataLayer.push"],
     },
-  }),
+  }),*/
   ],
   experimental: {
     devOverlay: true

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -28,9 +28,9 @@ const publishedTime = pubDate ? new Date(pubDate) : new Date();
 <html lang='en' class='h-full'>
   <!-- head -->
   <script
-    type='text/partytown'
+    async
     src='https://www.googletagmanager.com/gtag/js?id=G-8JYHCBXQZ5'></script>
-  <script type='text/partytown'>
+  <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() {
       dataLayer.push(arguments);


### PR DESCRIPTION
## Changes

Fix #32 Disabilitato partytown in attesa di fix da parte di astro/mozilla.


## Note

- Da testare in maniera più approfondita se possibile. Ho notato che la pagina "Old Wiki IPF Reddit" non funziona, non so se è un bug introdotto con questa modifica oppure è in fase di sviluppo visto che sul sito "live" non c'è
- In locale i link adesso sembrano funzionare sia su firefox che su chrome. Da verificare se installando in remoto continua a funzionare
- Da verificare se gli analytics google (gtag) continuano a funzionare avendoli importati senza partytown


https://github.com/emish89/italiapersonalfinance/assets/26444579/af0587a6-d479-43f4-8f28-7c171a3296d8



