### PR TITLE
docs: correct typos on work-and-taxes blog post

### DIFF
--- a/src/content/blog/work-and-taxes.mdx
+++ b/src/content/blog/work-and-taxes.mdx
@@ -75,11 +75,11 @@ L'ISEE (Indicatore della Situazione Economica Equivalente), è lo strumento che 
 per valutare la situazione economica delle famiglie che intendono richiedere una prestazione sociale agevolata (prestazione o riduzione del costo del servizio).
 Per ottenere l'assistenza necessaria alla compilazione della dichiarazione e delle domande da presentare agli Enti erogatori delle prestazioni
 è possibile rivolgersi ad un qualsiasi ufficio del CAF su tutto il territorio nazionale che gratuitamente potrà assistervi 
-nella compilazione della dichiarazione utile ad ottenere l'ISEE, e in base al valore potrà indicarvi a quli agevolazioni e bonus potete avere accesso.
+nella compilazione della dichiarazione utile ad ottenere l'ISEE, e in base al valore potrà indicarvi a quali agevolazioni e bonus potete avere accesso.
 
 I cittadini interessati alle prestazioni sociali agevolate legate al reddito possono recarsi agli sportelli del Caf Cisl per compilare la dichiarazione sostitutiva unica (DSU). 
 Ricordiamo che il servizio di assistenza per l'ISEE è completamente gratuito. 
-La dichiarazione può essere presentata in qualsiasi periodo dell'anno. Gli Isee elaborati nel 2023 hanno validità fino al 31 dicembre 2023.
+La dichiarazione può essere presentata in qualsiasi periodo dell'anno. Gli ISEE elaborati nel 2023 hanno validità fino al 31 dicembre 2023.
 
 [Documenti richiesti](https://www.cafcisl.it/schede-48-documenti_isee)
 
@@ -121,7 +121,7 @@ In particolare chi lavora come colf/badante e può aver diritto al bonus Irpef d
 che verrà riconosciuto presentando la dichiarazione. Chi nell'anno precedente ha percepito l'indennità di disoccupazione, 
 fa bene a verificare la corretta applicazione delle detrazioni applicate. 
 
-Sempre in caso di disoccupazione, chi nell'anno precedenete ha percepito sia lo stipendio che l'indennità, 
+Sempre in caso di disoccupazione, chi nell'anno precedente ha percepito sia lo stipendio che l'indennità, 
 avrà due CU (Certificazione unica, ex modello CUD): una del datore di lavoro e una dell'Inps e in questo caso è obbligatorio presentare la dichiarazione dei redditi, 
 ma anche chi ha percepito solo la disoccupazione, può presentare il modello 730 indicando l'Inps come sostituto d'imposta che effettuerà il conguaglio, 
 ottenendo prima eventuali rimborsi e verificando con i nostri operatori la corretta applicazione delle detrazioni applicate dall'Inps.
@@ -186,7 +186,7 @@ Le minusvalenze precedenti possono **ridurre la differenza tra il prezzo di vend
 
 Per i dividendi non esiste compensazione. La tassazione è pari al 26% anche su questi.
 
-Il broker può essere a regime dichiarativo o regime amministrativo. Nel primo caso, è necessario dichiarare le plusvalenze nel Quadro RT (plusvalenze di natura finanziaria) e pagare il 26% sulla plusvalenzacon F24. Nel secondo caso, il broker detrae automaticamente le tasse (26%) dalla plusvalenza prima del prelievo.
+Il broker può essere a regime dichiarativo o regime amministrato. Nel primo caso, è necessario dichiarare le plusvalenze nel Quadro RT (plusvalenze di natura finanziaria) e pagare il 26% sulla plusvalenza con F24. Nel secondo caso, il broker detrae automaticamente le tasse (26%) dalla plusvalenza prima del prelievo.
 
 ### **Ridurre Tasse su ETF**
 


### PR DESCRIPTION
## Changes

This PR just fixes a few typos that I found while reading the [Tasse e Lavoro article](https://www.italiapersonalfinance.it/blog/tasse-e-lavoro/#tasse-e-lavoro) 

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
