### PR TITLE
docs: correct typos on short-term-investment article

### DIFF
--- a/src/content/blog/short-term-investment.mdx
+++ b/src/content/blog/short-term-investment.mdx
@@ -59,8 +59,8 @@ Per poter confrontare i diversi Conti Deposito esiste il Sito [Deposifire](https
 
 
 
-PREMESSA:Sottolineo che per operare con i successivi prodotti è necessario essere in possesso di un Conto Titoli presso una Banca o Broker ed è consigliato 
-l’utilizzo solo se alle persone interessate e con conoscenze adeguate dei prodotti finanziari indicati.
+PREMESSA: Sottolineo che per operare con i successivi prodotti è necessario essere in possesso di un Conto Titoli presso una Banca o Broker ed è consigliato 
+l’utilizzo solo alle persone interessate e con conoscenze adeguate dei prodotti finanziari indicati.
 
 ## Fondo Obbligazionario Ultra Short-Term
 Il secondo livello introduce il fondo obbligazionario ultra short-term.
@@ -118,7 +118,7 @@ del pagamento programmato (bollo auto, operazione dentale ecc…) e selezionare 
 
 ## Conclusioni
 
-Cosa fare con tutto ciò che invece vogliamo investire? Ne iniziamo a parliamo qui:
+Cosa fare con tutto ciò che invece vogliamo investire? Ne iniziamo a parlare qui:
     <a href='/blog/prodotti-di-investimento'>
                 <button className='brutal-btn px-10 sanchez p-2' name='button'>
                             <span>Prodotti di investimento</span>


### PR DESCRIPTION
## Changes

This PR fixes a few typos that I have found while reading the [Fondo di Emergenza article](https://www.italiapersonalfinance.it/blog/investimenti-liquidi/).

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
