### PR TITLE
docs: correct a typo on pic-vs-pac article

### DIFF
--- a/src/content/blog/pic-vs-pac.mdx
+++ b/src/content/blog/pic-vs-pac.mdx
@@ -16,7 +16,7 @@ lastReviewer: 'u/emish89'
 # PIC vs PAC
 
 ## Premesse
-Se siete arrivati fino a qui e stiate considerando se partire con un PIC o un PAC, diamo per scontato che abbiate già un fondo di emergenza 
+Se siete arrivati fino a qui e state considerando se partire con un PIC o un PAC, diamo per scontato che abbiate già un fondo di emergenza 
 e che abbiate già letto l'articolo riguardante le basi degli investimenti. 
 
 In caso contrario li trovate qui:


### PR DESCRIPTION
## Changes

Correct a small typo on the [PIC vs PAC article](https://www.italiapersonalfinance.it/blog/pic-vs-pac/).

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
