### PR TITLE
docs(wiki): reorganize links order

### DIFF
--- a/src/content/blog/new-wiki.mdx
+++ b/src/content/blog/new-wiki.mdx
@@ -22,8 +22,8 @@ lastReviewer: 'u/lucaosti00'
 
 - [Strumenti per investimenti liquidi - Fondo Emergenza](/blog/investimenti-liquidi)
 - [PIC vs PAC](/blog/pic-vs-pac)
-- [Gli index funds](/blog/index-funds)
 - [I Fondi comuni di investimento](/blog/fondi-comuni-investimento)
+- [Gli index funds](/blog/index-funds)
 - [Gli ETF](/blog/etf)
 - [Le obbligazioni - wiki](/blog/obbligazioni)
 - [Le criptovalute](/blog/crypto)


### PR DESCRIPTION
## Changes
Nell' articolo riguardante gli [Index Funds](https://www.italiapersonalfinance.it/blog/index-funds/) c'è scritto:
```
Gli Index Funds sono in parte simili ai fondi comuni di investimento ma con una sostanziale differenza. ...
```
Tuttavia, l' articolo sui [fondi comuni di investimento](https://www.italiapersonalfinance.it/blog/fondi-comuni-investimento/) viene subito dopo nella [wiki](https://www.italiapersonalfinance.it/blog/wiki/), e un neofita che legge gli articoli in ordine di wiki potrebbe confondersi un' attimo.

Propongo quindi di spostare l' articolo sui fondi comuni di investimento appena prima di quello degli index funds, che ne pensate? 😃 

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
