### PR TITLE
docs(taxation): correct typo

### DIFF
--- a/src/content/blog/taxation.mdx
+++ b/src/content/blog/taxation.mdx
@@ -18,7 +18,7 @@ lastReviewer: 'u/emish89'
 
 Nel **regime amministrato**, il broker/banca fa da sostituto d'imposta e addebita in automatico tutte le tasse imponibili.
 L'investitore dunque non dovrà preoccuparsi di dichiarare nulla in quanto il broker farà tutto in automatico.
-Il regime amministrato è ideale per tutte quelle persone che vogliono la massima semplicità dal punto di vista fiscale, senza alcun richio fiscale.
+Il regime amministrato è ideale per tutte quelle persone che vogliono la massima semplicità dal punto di vista fiscale, senza alcun rischio fiscale.
 
 ## **Regime dichiarativo**
 


### PR DESCRIPTION
## Changes

This PR corrects a typo found in the [Tassazione investimenti article](https://www.italiapersonalfinance.it/blog/tassazione-investimenti/).


## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
