### PR TITLE
docs(loss-recovery): correct typos

### DIFF
--- a/src/content/blog/loss-recovery.mdx
+++ b/src/content/blog/loss-recovery.mdx
@@ -66,7 +66,7 @@ Ossia, quando chiuderemo la posizione, avremo una plusvalenza tassata minore.
 Molte obbligazioni hanno il vantaggio di avere una scadenza ed un flusso cedolare predeterminato. Questo può essere usato facilmente per il recupero delle minusvalenze.
 
 Dobbiamo differenziare tra due tipi di rendimento, quello nominale (il flusso cedolare) 
-e quello effettivo (flussso dedolare diviso prezzo di acquisto + eventuale plusvalenza se portato a scadenza). 
+e quello effettivo (flusso cedolare diviso prezzo di acquisto + eventuale plusvalenza se portato a scadenza). 
 Questo perché il rendimento effettivo tiene conto anche del prezzo di acquisto e del prezzo di vendita che, tipicamente, 
 se comprata in emissione e portata a scadenza è identico.
 
@@ -91,7 +91,7 @@ Esistono certificati chiamati **Maxi coupon** che sono nati proprio con lo scopo
 La base del ragionamento è avere un sottostante, che in base a delle regole proprie del certificato, 
 determina un flusso cedolare che entra nel computo dei redditi diversi. 
 Ovviamente al momento del pagamento della cedola (il maxi coupon), il certificato perde esattamente il valore erogato.
-Il recupero della minusvalenza e l'ipotetica vendita in perdita del certificato, permette di postporre la scadenza delle minusvalenze.
+Il recupero della minusvalenza e l'ipotetica vendita in perdita del certificato, permette di posporre la scadenza delle minusvalenze.
 
 ## Conclusioni
 


### PR DESCRIPTION
## Changes

Correct a few typos found in the [Recupero minusvalenze article](https://www.italiapersonalfinance.it/blog/mini-guida-al-recupero-delle-minusvalenze/).

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
