### PR TITLE
docs(degree-redemption): fix typos

### DIFF
--- a/src/content/blog/degree-redemption.mdx
+++ b/src/content/blog/degree-redemption.mdx
@@ -49,7 +49,7 @@ Una cosa che molto spesso non viene menzionata è che l’importo del riscatto d
 
 ## **_Esempio 1:_**
 
-Mario ha una RAL poco sopra i 40.000 €, ha un imponibile di circa 35.500 € e paga annualmente circa 9.500 € di IRPEF. Mario ricade appieno nello scaglione del 38 % (con la nuova riforma 35%). Mario vuole riscattare i 5 anni e sceglie di farlo in 10 anni (120 rate).
+Mario ha una RAL poco sopra i 40.000 €, ha un imponibile di circa 35.500 € e paga annualmente circa 9.500 € di IRPEF. Mario ricade appieno nello scaglione del 38% (con la nuova riforma 35%). Mario vuole riscattare i 5 anni e sceglie di farlo in 10 anni (120 rate).
 
 L’importo che Mario dovrà pagare annualmente sarà circa 2.630 €, circa 220 € mensilmente. Il reddito imponibile di Mario si ridurrà però di 2.630 € e le imposte che dovrà pagare non saranno più 9.500 € ma 8.500 €. Il risparmio sull’IRPEF sarà quindi di circa 1.000 €. Su 10 anni, 10.000 €.
 
@@ -75,7 +75,7 @@ Con circa 26.270 € (che si possono trasformare in circa 16.000 € o meno tene
 
 ## **Come si fa**
 
-Non mi dilungo, è quasi banale. Basta avere lo SPID, collegarsi al sito dell’INPS, e seguire le istruzioni. La procedura dura abbastanza poco. Una volta conclusa, è necessario attendere l’approvazione (qualche mese). Una volta approvato, si consiglia di utilizzare il pagamento automatico mensile dal proprio conto corrente, altrimenti si devono pagare 120 rate manualmente. In ogni caso sul sito sono ripotate tutte le istruzioni.
+Non mi dilungo, è quasi banale. Basta avere lo SPID, collegarsi al sito dell’INPS, e seguire le istruzioni. La procedura dura abbastanza poco. Una volta conclusa, è necessario attendere l’approvazione (qualche mese). Una volta approvato, si consiglia di utilizzare il pagamento automatico mensile dal proprio conto corrente, altrimenti si devono pagare 120 rate manualmente. In ogni caso sul sito sono riportate tutte le istruzioni.
 
 ## **Ma quindi, a chi conviene farlo? Conclusioni**
 


### PR DESCRIPTION
## Changes

Correct a typo found on the [Riscatto Laurea agevolato article](https://www.italiapersonalfinance.it/blog/riscatto-laurea-agevolato/).

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->
