### PR TITLE
Link fix e parafrasi paragrafo rischi

### DIFF
--- a/src/data/blog/bond.mdx
+++ b/src/data/blog/bond.mdx
@@ -24,7 +24,7 @@ Graditi infine sono i commenti, i consigli e le critiche.
 
 Grazie a tutti.
 
-Qui dei link al sito del governo che parlano di [Obbligazioni](http://www.quellocheconta.gov.it/it/strumenti/bancari-finanziari/obbligazione) e [Titoli di Stato](https://www.quellocheconta.gov.it/it/strumenti/bancari-finanziari/titoli-di-stato).
+Qui dei link al sito della Banca d'Italia che parlano di [Obbligazioni](https://economiapertutti.bancaditalia.it/aree-tematiche/risparmio-e-investimenti/le-obbligazioni/index.html) e [Titoli di Stato](https://economiapertutti.bancaditalia.it/aree-tematiche/risparmio-e-investimenti/i-titoli-di-stato/index.html).
 
 
 ## COSA SONO LE OBBLIGAZIONI
@@ -63,11 +63,11 @@ Il tasso, che di solito è lo strumento usato per la remunerazione del rischio, 
 
 ## PRINCIPALI RISCHI
 
-Importante è capire che non esistono, e non possono esistere, obbligazioni prive di rischio e che il rischio non è solo quello di perdere il capitale.
+È importante capire che non esistono, e non possono esistere, obbligazioni prive di rischio. Il rischio massimo è il default dell'emittente con la perdita totale del capitale, ma esistono dinamiche che possono erodere il capitale investito anche qualora il titolo venga regolarmente rimborsato.
 
-Altrettanto importante è imparare a valutare i rischi per capire quali siamo disposti a sopportare e quali no, ed in via marginale per capire se un’obbligazione è davvero interessante.
+È altrettanto importante conoscere e imparare a valutare i rischi per capire quali siamo disposti a sopportare e quali no, ed in via marginale per capire se un’obbligazione è davvero interessante.
 
-Ovviamente più alto il rischio, più alta è la remunerazione (che il mercato pretende); e qualsiasi rischio, anche se in misure diverse, influisce sulla generazione del prezzo.
+Generalmente più alto è il rischio, più alta è la remunerazione (che il mercato pretende); e qualsiasi rischio, anche se in misure diverse, influisce sulla generazione del prezzo.
 
 Attenzione che i rischi non sono statici, ma dinamici (ad es. l’Italia ha peggiorato il proprio rischio emittente negli ultimi anni), per cui il primo fattore di rischio di un’obbligazione è la sua durata: più lunga è più sono esposto ad incognite ed a possibili cambiamenti negativi, quindi a parità di altre condizioni, maggiore è la durata, maggiore sarà la remunerazione.
 


### PR DESCRIPTION
Sostituiti i link rotti alla Banca d'Italia.

Piccola riformulazione del paragrafo riguardante i rischi. #689 

