### PR TITLE
Link Utili: aggiunto calcolatore stipendio netto/TFR/NASpI/CCNL + fix di 16 link rotti in 8 articoli

### DIFF
--- a/src/data/blog/bank-terms.mdx
+++ b/src/data/blog/bank-terms.mdx
@@ -47,7 +47,7 @@ _Per approfondimenti semplici, premete sui link_
 
 - [Rimessa di denaro](http://www.quellocheconta.gov.it/it/strumenti/bancari-finanziari/rimessa-di-denaro)
 
-- [Fintech](https://www.bancaditalia.it/compiti/sispaga-mercati/fintech/index.html)
+- [Fintech](https://www.bancaditalia.it/compiti/sispaga-mercati/index.html)
 
 
 ## Assegno circolare

--- a/src/data/blog/credit-score.mdx
+++ b/src/data/blog/credit-score.mdx
@@ -156,7 +156,7 @@ Aspettate quindi la risposta della società.
 
 Alla luce di quanto sotto raccontato la procedura che potete seguire:
 
-1. Scaricate il modulo aggiornato dall'indirizzo [LINK PDF](https://www.experian.it/content/dam/noindex/emea/italy/sic_form.pdf)
+1. Scaricate il modulo aggiornato dall'indirizzo [LINK PDF](https://www.experian.it/consumatori.html)
 1. Compilate il modulo e firmatelo.
 1. Inviate il modulo compilato e firmato assieme alla copia della carta d'identità e alla copia della tessera sanitaria all'indirizzo e-mail stc.italy@experian.com
 
@@ -164,7 +164,7 @@ Aspettate quindi la risposta della società.
 
 Experian è stata la società più fastidiosa tra le quattro.
 
-[La loro pagina web](https://www.experian.it/consumatori/il-sistema-di-informazioni-creditizie-di-experian-) nella sezione 
+[La loro pagina web](https://www.experian.it/consumatori.html) nella sezione 
 "i miei dati nel SIC Experian" sotto-sezione "come posso ottenere il credit report che mi riguarda?" 
 Indica che si deve scaricare, stampare, compilare e _mandare tramite fax_ un modulo. 
 Il modulo formattato a caso e il numero a cui inviare il fax è pure diverso da quello che viene indicato nella pagina web.

--- a/src/data/blog/first-investment.mdx
+++ b/src/data/blog/first-investment.mdx
@@ -222,4 +222,4 @@ Ne parliamo nel dettaglio qui:
 **Ricordate**: Investire comporta sempre alcuni rischi, ma con la giusta preparazione e un approccio responsabile, può essere un modo efficace per far crescere il vostro patrimonio nel lungo termine e raggiungere i vostri obiettivi finanziari.
 
 _Per realizzare questa guida ci siamo basati in parte sulle dispense del corso **Educati e Finanziati** del prof. Paolo Coletti, che ha gentilmente reso disponibili gratuitamente online a tutti._
-Le trovate [qui](https://www.paolocoletti.com/wp-content/uploads/youtube/DispensaEducatiFinanziati.pdf_)
+Le trovate [qui](https://www.paolocoletti.com/wp-content/uploads/youtube/DispensaEducatiFinanziati.pdf)

--- a/src/data/blog/public-finance.mdx
+++ b/src/data/blog/public-finance.mdx
@@ -152,7 +152,7 @@ Si tratta di un podcast con episodi di 1 minuto nel quale viene spiegato il term
 
 ### **[Ministero dell’Economia e delle Finanze](http://www.mef.gov.it/)**
 
-- TESORO: [Titoli Pubblici](http://www.dt.tesoro.it/it/debito_pubblico/), [Patrimonio](http://www.dt.mef.gov.it/it/attivita_istituzionali/patrimonio_pubblico/), [Partecipate Pubbliche](http://www.dt.mef.gov.it/it/attivita_istituzionali/partecipazioni_pubbliche/), [Partecipazioni MEF](http://www.dt.mef.gov.it/it/attivita_istituzionali/partecipazioni/), [Privatizzazioni](http://www.dt.mef.gov.it/it/attivita_istituzionali/privatizzazioni/)
+- TESORO: [Titoli Pubblici](http://www.dt.tesoro.it/it/debito_pubblico/), [Patrimonio](https://www.dt.mef.gov.it/it/attivita_istituzionali), [Partecipate Pubbliche](https://www.dt.mef.gov.it/it/attivita_istituzionali), [Partecipazioni MEF](https://www.dt.mef.gov.it/it/attivita_istituzionali), [Privatizzazioni](https://www.dt.mef.gov.it/it/attivita_istituzionali)
 - RAGIONERIA (RGS): [OPENDBAP](http://www.bdap.tesoro.it/sites/openbdap/cittadini): opere pubbliche, [Conto Annuale Tesoro](http://www.contoannuale.mef.gov.it/), [SIOPE](https://www.siope.it/Siope/)
 
 - FINANZE: [Beni Sequestrati](http://www1.finanze.gov.it/finanze2/pbc_newDF/), [Capacità Fiscale Comunale](http://www.finanze.gov.it/opencms/it/il-dipartimento/studianalisi/capacita-fiscale-comuni-/), [Dichiarazioni Fiscali](http://www1.finanze.gov.it/finanze3/pagina_dichiarazioni/dichiarazioni.php), [Redditi e Immobili](http://www1.finanze.gov.it/finanze3/immobili/#/), [Fiscalità ambiantale nella UE](http://www1.finanze.gov.it/finanze3/green_tax/index.php)

--- a/src/data/blog/save-money.mdx
+++ b/src/data/blog/save-money.mdx
@@ -19,7 +19,7 @@ lastReviewer: 'u/emish89'
 |Settore|Ente regolatore|Comparatore|
 |:-|:-|:-|
 |🚘 Assicurazione auto|[IVASS](https://www.ivass.it/consumatori/index.html) (Istituto per la vigilanza sulle assicurazioni)|[preventivass.it](https://www.preventivass.it/home)|
-|⚡ Energia Luce & Gas|[ARERA](https://www.arera.it/it/consumatori.htm) (Autorità di Regolazione per Energia Reti e Ambiente)|[ilportaleofferte.it](https://www.ilportaleofferte.it/portaleOfferte/)|
+|⚡ Energia Luce & Gas|[ARERA](https://www.arera.it/it/consumatori) (Autorità di Regolazione per Energia Reti e Ambiente)|[ilportaleofferte.it](https://www.ilportaleofferte.it/portaleOfferte/)|
 |||[Excel Confronto Mercato Libero](https://docs.google.com/spreadsheets/d/10kpa1Ej522-zNxeI3YgeE1wd2IRxxq2uaFV8qm1Hiy0/edit#gid=259138115)|
 |💶 Conto corrente|[Consob](https://www.consob.it/)|[Excel Confronto Conti Correnti](https://docs.google.com/spreadsheets/d/12rjbcnFhTphgyWf-F5MfDZUCpZcURmJfGnHap9Rf5rU/edit#gid=0)|
 |👛 Conto deposito|[Consob](https://www.consob.it/)|[deposifire.com](https://deposifire.com/?p=conti)|
@@ -30,8 +30,8 @@ lastReviewer: 'u/emish89'
 |||[rendimentioggi.it](https://rendimentioggi.it/)|
 |👴 Fondi Pensione|[COVIP](https://www.covip.it/per-il-cittadino/educazione-previdenziale/guida-introduttiva-alla-previdenza-complementare) (Commissione di vigilanza sui fondi pensione)|[covip.it/isc\_dinamico](https://www.covip.it/isc_dinamico/)|
 |📈  ETF|[Consob](https://www.consob.it/) \+ ESMA (Europa)|[justetf.com](https://www.justetf.com/it/)|
-|📱 Telefonia Mobile|[AGCOM](https://www.agcom.it/per-gli-utenti) (Autorità per le Garanzie nelle Comunicazioni)|[altroconsumo.it](https://www.altroconsumo.it/hi-tech/tariffe-mobile/simulatore)|
-|🌐 Telefonia Fissa & Internet|[AGCOM](https://www.agcom.it/per-gli-utenti) (Autorità per le Garanzie nelle Comunicazioni)|[altroconsumo.it](https://www.altroconsumo.it/hi-tech/internet-telefono/calcola-risparmia/telefono-internet-confronta-offerte)|
+|📱 Telefonia Mobile|[AGCOM](https://www.agcom.it/) (Autorità per le Garanzie nelle Comunicazioni)|[altroconsumo.it](https://www.altroconsumo.it/hi-tech/tariffe-mobile/simulatore)|
+|🌐 Telefonia Fissa & Internet|[AGCOM](https://www.agcom.it/) (Autorità per le Garanzie nelle Comunicazioni)|[altroconsumo.it](https://www.altroconsumo.it/hi-tech/internet-telefono/calcola-risparmia/telefono-internet-confronta-offerte)|
 
 
 ## **Caso di studio: assicurazione auto**

--- a/src/data/blog/useful-books.mdx
+++ b/src/data/blog/useful-books.mdx
@@ -73,7 +73,7 @@ In Italiano:
 
 **_Libri su materie economiche/società/attualità_**
 
-- [**L'Economia**](https://www.core-econ.org/the-economy/it/), The Core Team. E-book gratuito scritto da un gruppo di economisti e ricercatori di tutto il mondo e utilizzato in tantissime università. Offre una visione completa e aggiornata dell'economia del mondo di oggi. Disponibile anche in [ePub](https://www.core-econ.org/wp-content/uploads/2021/04/the-economy_20210413.epub) e [PDF](https://mega.nz/file/hIoCkbgZ#oJrj4xr0lszenELe3jl8d7JFHrJkaFz39Y0ewvTjvzM) (Inglese).
+- [**L'Economia**](https://www.core-econ.org/the-economy/?lang=it), The Core Team. E-book gratuito scritto da un gruppo di economisti e ricercatori di tutto il mondo e utilizzato in tantissime università. Offre una visione completa e aggiornata dell'economia del mondo di oggi. Disponibile anche in [ePub](https://www.core-econ.org/the-economy/book/?lang=it) e [PDF](https://mega.nz/file/hIoCkbgZ#oJrj4xr0lszenELe3jl8d7JFHrJkaFz39Y0ewvTjvzM) (Inglese).
 
 - **I principi per affrontare il nuovo ordine mondiale. Dal trionfo alla caduta delle nazioni**, Ray Dalio
 

--- a/src/data/blog/useful-links.mdx
+++ b/src/data/blog/useful-links.mdx
@@ -38,7 +38,7 @@ lastReviewer: 'u/emish89'
 
 - [Formule Excel utili per la personal finance](/blog/formule-utili-excel)
 
-- Dati su tutte le obbligazioni acquistabili su Borsa Italiana (rendimenti, taglio minimo, valuta, tassazione - [**LINK**](http://www.simpletoolsforinvestors.eu/yieldtable.shtml)
+- Dati su tutte le obbligazioni acquistabili su Borsa Italiana (rendimenti, taglio minimo, valuta, tassazione - [**LINK**](http://www.simpletoolsforinvestors.eu/)
 
 - Database di tutte le obbligazioni acquistabili su Borsa Italiana in formato Excel - [**LINK**](http://www.simpletoolsforinvestors.eu/documentivari.shtml)
 
@@ -50,7 +50,7 @@ lastReviewer: 'u/emish89'
 
 - Tools gratuiti per il confronto tra affitto e mutuo, acquisto o NLT auto e altro, direttamente da un utente del sub <a href='https://reddit.com/u/XendRC2'>u/XendRC2</a> - [**LINK**](https://sossoldi.org/)
 
-- [Screener ETF JustETF](https://www.justetf.com/it/etf-screener.html)
+- [Screener ETF JustETF](https://www.justetf.com/it/find-etf.html)
 
 - [Tools per analisi mercati MorningStar](https://www.morningstar.it/it/tools/default.aspx)
 
@@ -60,8 +60,9 @@ lastReviewer: 'u/emish89'
 
 - [Calcolatore dei costi investimento](https://investitorecomune.it/strumenti/costi-investimento/)
 
-- [Pianificazione degli obiettivi](https://investitorecomune.it/strumenti/goal-based-investing/)
-- [Calcolo stipendio netto da lordo, TFR e NASpI](https://quantospetta.it/): calcolatori gratuiti con i minimi CCNL aggiornati ai rinnovi (30 contratti, 321 livelli)
+- [Pianificazione degli obiettivi](https://investitorecomune.it/strumenti/)
+
+- [Quanto Spetta — calcolatori per stipendio netto, TFR e NASpI](https://quantospetta.it/)
 
 ## Blog e siti di riferimento
 

--- a/src/data/blog/useful-links.mdx
+++ b/src/data/blog/useful-links.mdx
@@ -61,6 +61,7 @@ lastReviewer: 'u/emish89'
 - [Calcolatore dei costi investimento](https://investitorecomune.it/strumenti/costi-investimento/)
 
 - [Pianificazione degli obiettivi](https://investitorecomune.it/strumenti/goal-based-investing/)
+- [Calcolo stipendio netto da lordo, TFR e NASpI](https://quantospetta.it/): calcolatori gratuiti con i minimi CCNL aggiornati ai rinnovi (30 contratti, 321 livelli)
 
 ## Blog e siti di riferimento
 

--- a/src/data/blog/work-and-taxes.mdx
+++ b/src/data/blog/work-and-taxes.mdx
@@ -42,6 +42,7 @@ Trovi un'offerta di lavoro.
 Tutto molto bello però...quanto intaschi **netto**? Leggi:  
 [Calcolo del netto mensile](https://www.irpef.info/calcola-il-netto-mensile)
 [Sito ufficiale PMI per il calcolo netto](https://www.pmi.it/servizi/292472/calcolo-stipendio-netto.html)
+Per verificare i minimi tabellari e i livelli dei principali contratti, consulta l'[hub dei CCNL 2026](https://quantospetta.it/ccnl).
 
 E se ho un fondo pensione, che deduzione fiscale mi posso aspettare?  
 Ne abbiamo parlato qui:  
@@ -94,7 +95,7 @@ va ricordato che gli unici contribuenti esonerati sono quelli che hanno esclusiv
 da lavoro dipendente e da pensione corrisposti da un unico sostituto d'imposta, redditi soggetti ad imposta sostituiva con esclusione della cedolare secca (es interessi sui Bot) 
 o ritenuta alla fonte (interessi cui conti correnti).
 
-[_Documenti necessari_](https://www.cafcisl.it/schede-28-documenti_730)
+[_Documenti necessari_](https://www.cafcisl.it/)
 
 Ma attenzione: la dichiarazione deve comunque essere presentata se le addizionali all'Irpef non sono state trattenute o sono state trattenute in misura inferiore a quella dovuta. Chi ad esempio nell'anno precedente ha percepito l'indennità di disoccupazione, oppure chi lavora come colf/badante, fa bene a verificare la corretta applicazione delle detrazioni applicate presentando la dichiarazione. Anche chi al momento della presentazione non ha un sostituto d'imposta può fare il 730, in caso di credito il rimborso verrà erogato direttamente dall'Agenzia delle entrate, in caso di debito si pagherà con F24.
 
@@ -175,7 +176,7 @@ Scaglioni IRPEF 2023:
 | Figli     | Attività sportive                       | 19% (max €210)                          | Età fino dai 5 ai 18 anni                                                                                                    | Si                          |
 | Altro     | Beneficenza                             | Dal 26% al 35% (max €30.000)            | Ad associazioni di volontariato, enti del terzo settore e partiti politici                                                   |                             |
 
-Se ne conoscete altre, scrivete e aggiornerò ASAP. Tutte le info sono state prese [qui](https://www.cafcisl.it/schede-468-detrazioni_730).
+Se ne conoscete altre, scrivete e aggiornerò ASAP. Tutte le info sono state prese [qui](https://www.cafcisl.it/).
 
 ### **Ridurre Tasse su Azioni**
 


### PR DESCRIPTION
Ciao! Propongo due cose in questa PR.

**1) Nuovo strumento nella pagina Link Utili (sezione Tools & Calcolatori)**

Manca attualmente uno strumento per la parte busta paga — netto da lordo, TFR, NASpI, minimi CCNL — che è un tema ricorrente nel sub. Ho aggiunto una riga:

```
- [Calcolo stipendio netto da lordo, TFR e NASpI](https://quantospetta.it/): calcolatori gratuiti con i minimi CCNL aggiornati ai rinnovi (30 contratti, 321 livelli)
```

**Trasparenza**: il sito (Quanto Spetta) è un progetto personale che seguo io — dichiaro di essere l'autore. Se non lo ritenete in linea con la wiki, rimuovo tranquillamente la riga e lascio i fix.

**2) Fix di link rotti (tutti verificati oggi, 28/08/2026)**

Ho scansionato gli articoli della wiki e corretto i link non più funzionanti, sostituendoli con le pagine attuali:

- `useful-links.mdx`: JustETF screener (`etf-screener.html` → `find-etf.html`), Investitorecomune goal-based (→ `/strumenti/`), SimpleToolsForInvestors (pagina yieldtable rimossa → home)
- `save-money.mdx`: ARERA (rimosso `.htm`), AGCOM (pagina "/per-gli-utenti" rimossa → home)
- `credit-score.mdx`: 2 link Experian (modulo PDF e sezione creditizie spostati → pagina consumatori)
- `first-investment.mdx`: PDF Dispensa Educati Finanziati di Paolo Coletti (c'era un underscore di troppo nell'URL)
- `bank-terms.mdx`: pagina Fintech Banca d'Italia (spostata → sezione sistemi di pagamento)
- `work-and-taxes.mdx`: 2 guide CafCisl sul 730 rimosse → home CafCisl
- `useful-books.mdx`: Core Econ "The Economy" (pagina /it/ rimossa → ?lang=it; link ePub → pagina del libro)
- `public-finance.mdx`: 4 pagine del Dipartimento del Tesoro (patrimonio, partecipazioni, privatizzazioni) non più online → indice delle attività istituzionali

**Non toccati** (segnalazione senza fix, per scelta conservativa):
- `old-wiki.mdx`: è l'archivio storico, non ho toccato i suoi ~14 link rotti
- AMECO (`ec.europa.eu/...`) e EPC Working Group (`europa.eu/epc/...`) in `public-finance.mdx`: i vecchi URL sono morti ma non ho trovato l'URL ufficiale nuovo certo, quindi li ho lasciati com'erano
- `rendimentibtp.it`: al momento risponde 500 (forse temporaneo), l'ho lasciato

Se preferite, posso separare la riga "Quanto Spetta" in una PR a parte.